### PR TITLE
Added some information about the MEE6 configuration in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Mee6LevelsApi.getUserXp(guildId, userId).then(user => {
 	console.log(`${user.tag} is at level ${user.level} and rank ${user.rank}.`);
 });
 ```
+
+## Configuration
+
+Open the leaderboard settings in the MEE6 dashboard and enable the option: `Make my server's leaderboard public`. It is not possible to fetch data from the dashboard if this option is not enabled and the error 'Response code 401' will be returned.


### PR DESCRIPTION
I've added some basic configuration information in the readme. 

I've been getting some errors lately and I realised that there is a configuration to disable the leaderboard's public page. If it's not enabled, it throws an error.